### PR TITLE
Up the send/receive limits for string JsonPrimitives

### DIFF
--- a/common/src/main/java/uk/me/desert_island/rer/RoughlyEnoughResources.java
+++ b/common/src/main/java/uk/me/desert_island/rer/RoughlyEnoughResources.java
@@ -137,7 +137,7 @@ public class RoughlyEnoughResources {
     private static void writeJsonPrimitive(FriendlyByteBuf buf, JsonPrimitive primitive) {
         if (primitive.isString()) {
             buf.writeByte(1);
-            buf.writeUtf(primitive.getAsString());
+            buf.writeUtf(primitive.getAsString(), Integer.MAX_VALUE);
         } else if (primitive.isBoolean()) {
             buf.writeByte(primitive.getAsBoolean() ? 3 : 2);
         } else if (primitive.isNumber()) {
@@ -210,7 +210,7 @@ public class RoughlyEnoughResources {
     private static JsonPrimitive readJsonPrimitive(int type, FriendlyByteBuf buf) {
         switch (type) {
             case 1:
-                return new JsonPrimitive(buf.readUtf());
+                return new JsonPrimitive(buf.readUtf(Integer.MAX_VALUE / 4));
             case 2:
                 return new JsonPrimitive(false);
             case 3:


### PR DESCRIPTION
Quick and dirty fix for #60.
The particular issue is caused by the VanillaTweaks Armor Statues' book NBT that is part of a loot table that is slightly too large to transfer because of the default `writeUtf()` / `readUtf()` limits of 32767 bytes/characters.

This simply ups those limits to their theoretical maximum values.
For `writeUtf()` that is `Integer.MAX_VALUE`, the number of bytes, for `readUtf()` it is `Integer.MAX_VALUE / 4`, the number of characters (`readUtf()` internally multiplies the limit by 4 before comparing with the number of bytes).

I did this for 1.18.2 because I'm currently playing on it but it works for 1.19 just the same.